### PR TITLE
Update utc datetime handling

### DIFF
--- a/solarpark/models/leads.py
+++ b/solarpark/models/leads.py
@@ -1,9 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List, Optional
 
 from pydantic import BaseModel, ConfigDict
-
-from solarpark.persistence.database import utcnow
 
 
 class Lead(BaseModel):
@@ -55,7 +53,7 @@ class LeadCreateRequest(BaseModel):
     existing_id: Optional[int] = None
     quantity_shares: int
     generate_certificate: bool = False
-    purchased_at: datetime = utcnow()
+    purchased_at: datetime = datetime.now(timezone.utc)
 
 
 class LeadUpdateRequest(BaseModel):

--- a/solarpark/persistence/database.py
+++ b/solarpark/persistence/database.py
@@ -1,8 +1,5 @@
 from sqlalchemy import create_engine
-from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.orm import declarative_base, sessionmaker
-from sqlalchemy.sql import expression
-from sqlalchemy.types import DateTime
 
 from solarpark.settings import settings
 
@@ -19,18 +16,3 @@ def get_db():
         yield db
     finally:
         db.close()
-
-
-class utcnow(expression.FunctionElement):
-    type = DateTime()
-    inherit_cache = True
-
-
-@compiles(utcnow, "postgresql")
-def pg_utcnow(element, compiler, **kw):  # pylint: disable=W0613
-    return "TIMEZONE('utc', CURRENT_TIMESTAMP)"
-
-
-@compiles(utcnow, "sqlite")
-def sqlite_utcnow(element, compiler, **kw):  # pylint: disable=W0613
-    return "DATETIME('now', 'utc')"

--- a/solarpark/persistence/models/dividends.py
+++ b/solarpark/persistence/models/dividends.py
@@ -1,6 +1,6 @@
-from sqlalchemy import Boolean, Column, DateTime, Float, Integer
+from sqlalchemy import Boolean, Column, DateTime, Float, Integer, func
 
-from solarpark.persistence.database import Base, utcnow
+from solarpark.persistence.database import Base
 
 
 class Dividend(Base):
@@ -10,5 +10,5 @@ class Dividend(Base):
     dividend_per_share = Column(Float, nullable=False)
     payment_year = Column(Integer, nullable=False, unique=True)
     completed = Column(Boolean, nullable=False)
-    created_at = Column(DateTime, server_default=utcnow())
-    updated_at = Column(DateTime, onupdate=utcnow())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/solarpark/persistence/models/economics.py
+++ b/solarpark/persistence/models/economics.py
@@ -1,7 +1,7 @@
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, func
 from sqlalchemy.orm import relationship
 
-from solarpark.persistence.database import Base, utcnow
+from solarpark.persistence.database import Base
 from solarpark.persistence.models.members import Member
 
 
@@ -19,8 +19,8 @@ class Economics(Base):
     disbursed = Column(Float, nullable=True)
     last_dividend_year = Column(Integer, nullable=False)
     issued_dividend = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, server_default=utcnow())
-    updated_at = Column(DateTime, onupdate=utcnow())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     # Relationships
     members = relationship(Member)

--- a/solarpark/persistence/models/error_log.py
+++ b/solarpark/persistence/models/error_log.py
@@ -1,6 +1,6 @@
-from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, func
 
-from solarpark.persistence.database import Base, utcnow
+from solarpark.persistence.database import Base
 
 
 class ErrorLog(Base):
@@ -11,5 +11,5 @@ class ErrorLog(Base):
     share_id = Column(String, nullable=True)
     comment = Column(String, nullable=False)
     resolved = Column(Boolean, nullable=False)
-    created_at = Column(DateTime, server_default=utcnow())
-    updated_at = Column(DateTime, onupdate=utcnow())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/solarpark/persistence/models/leads.py
+++ b/solarpark/persistence/models/leads.py
@@ -1,6 +1,6 @@
-from sqlalchemy import Boolean, Column, DateTime, Integer, String
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, func
 
-from solarpark.persistence.database import Base, utcnow
+from solarpark.persistence.database import Base
 
 
 class Lead(Base):
@@ -20,6 +20,6 @@ class Lead(Base):
     existing_id = Column(Integer, nullable=True)
     quantity_shares = Column(Integer, nullable=False)
     generate_certificate = Column(Boolean, nullable=True)
-    purchased_at = Column(DateTime, server_default=utcnow())
-    created_at = Column(DateTime, server_default=utcnow())
-    updated_at = Column(DateTime, onupdate=utcnow())
+    purchased_at = Column(DateTime(timezone=True), server_default=func.now())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/solarpark/persistence/models/members.py
+++ b/solarpark/persistence/models/members.py
@@ -1,6 +1,6 @@
-from sqlalchemy import Column, DateTime, Integer, String
+from sqlalchemy import Column, DateTime, Integer, String, func
 
-from solarpark.persistence.database import Base, utcnow
+from solarpark.persistence.database import Base
 
 
 class Member(Base):
@@ -19,5 +19,5 @@ class Member(Base):
     bank = Column(String, nullable=True)
     swish = Column(String, nullable=True)
     year = Column(DateTime, nullable=True)
-    created_at = Column(DateTime, server_default=utcnow())
-    updated_at = Column(DateTime, onupdate=utcnow())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/solarpark/persistence/models/payments.py
+++ b/solarpark/persistence/models/payments.py
@@ -1,7 +1,7 @@
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, func
 from sqlalchemy.orm import relationship
 
-from solarpark.persistence.database import Base, utcnow
+from solarpark.persistence.database import Base
 from solarpark.persistence.models.members import Member
 
 
@@ -13,8 +13,8 @@ class Payment(Base):
     year = Column(Integer, nullable=True)
     amount = Column(Float, nullable=True)
     paid_out = Column(Boolean, nullable=True)
-    created_at = Column(DateTime, server_default=utcnow())
-    updated_at = Column(DateTime, onupdate=utcnow())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     # Relationships
     members = relationship(Member)

--- a/solarpark/persistence/models/shares.py
+++ b/solarpark/persistence/models/shares.py
@@ -1,7 +1,7 @@
-from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String
+from sqlalchemy import Boolean, Column, DateTime, Float, ForeignKey, Integer, String, func
 from sqlalchemy.orm import relationship
 
-from solarpark.persistence.database import Base, utcnow
+from solarpark.persistence.database import Base
 from solarpark.persistence.members import Member
 
 
@@ -15,8 +15,8 @@ class Share(Base):
     current_value = Column(Float, nullable=False)
     purchased_at = Column(DateTime, nullable=False)
     from_internal_account = Column(Boolean, nullable=False)
-    created_at = Column(DateTime, server_default=utcnow())
-    updated_at = Column(DateTime, onupdate=utcnow())
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
 
     # Relationships
     members = relationship(Member)


### PR DESCRIPTION
Efter senaste uppdatering av paket fick vi en del Pydantic-fel i vår egen implementation av UTC datetime i pgsql. Denna branch löser detta och använder det rekommenderade sättet att hantera UTC datetimes vid exempelvis uppskapandet av medlemmar och andelar.